### PR TITLE
refactor: counter bar starts with 0 after reset

### DIFF
--- a/counter/script.js
+++ b/counter/script.js
@@ -17,6 +17,7 @@ main.addEventListener("click", increaseCounter);
 
 function resetCounter() {
   counter = 0;
+  colorCounter = 0;
   label.innerText = counter;
   main.style.setProperty("--counter", 0 + "%");
   button.blur();


### PR DESCRIPTION
The colorCounter has to set to 0 in the reset-function. Without this command the color bar will continue with the value before the reset.